### PR TITLE
docs: Fix a few typos

### DIFF
--- a/2.Firmware/HoloCubic-fw/lib/FastLED/README.md
+++ b/2.Firmware/HoloCubic-fw/lib/FastLED/README.md
@@ -63,12 +63,12 @@ HL1606, and "595"-style shift registers are no longer supported by the library. 
 
 ## Supported platforms
 
-Right now the library is supported on a variety of arduino compatable platforms.  If it's ARM or AVR and uses the arduino software (or a modified version of it to build) then it is likely supported.  Note that we have a long list of upcoming platforms to support, so if you don't see what you're looking for here, ask, it may be on the roadmap (or may already be supported).  N.B. at the moment we are only supporting the stock compilers that ship with the arduino software.  Support for upgraded compilers, as well as using AVR studio and skipping the arduino entirely, should be coming in a near future release.
+Right now the library is supported on a variety of arduino compatible platforms.  If it's ARM or AVR and uses the arduino software (or a modified version of it to build) then it is likely supported.  Note that we have a long list of upcoming platforms to support, so if you don't see what you're looking for here, ask, it may be on the roadmap (or may already be supported).  N.B. at the moment we are only supporting the stock compilers that ship with the arduino software.  Support for upgraded compilers, as well as using AVR studio and skipping the arduino entirely, should be coming in a near future release.
 
 * Arduino & compatibles - straight up arduino devices, uno, duo, leonardo, mega, nano, etc...
 * Arduino Yún
 * Adafruit Trinket & Gemma - Trinket Pro may be supported, but haven't tested to confirm yet
-* Teensy 2, Teensy++ 2, Teensy 3.0, Teensy 3.1/3.2, Teensy LC, Teensy 3.5, Teensy 3.6, and Teensy 4.0 - arduino compataible from pjrc.com with some extra goodies (note the teensy 3, 3.1, and LC are ARM, not AVR!)
+* Teensy 2, Teensy++ 2, Teensy 3.0, Teensy 3.1/3.2, Teensy LC, Teensy 3.5, Teensy 3.6, and Teensy 4.0 - arduino compatible from pjrc.com with some extra goodies (note the teensy 3, 3.1, and LC are ARM, not AVR!)
 * Arduino Due and the digistump DigiX
 * RFDuino
 * SparkCore

--- a/2.Firmware/HoloCubic-fw/lib/TFT_eSPI/README.md
+++ b/2.Firmware/HoloCubic-fw/lib/TFT_eSPI/README.md
@@ -42,7 +42,7 @@ Displays using the following controllers are supported:
 
 ILI9341 and ST7796 SPI based displays are recommended as starting point for experimenting with this library.
 
-The library supports some TFT displays designed for the Raspberry Pi (RPi) that are based on a ILI9486 or ST7796 driver chip with a 480 x 320 pixel screen. The ILI9486 RPi display must be of the Waveshare design and use a 16 bit serial interface based on the 74HC04, 74HC4040 and 2 x 74HC4094 logic chips. Note that due to design variations between these displays not all RPi displays will work with this library, so purchaing a RPi display of these types soley for use with this library is not recommended.
+The library supports some TFT displays designed for the Raspberry Pi (RPi) that are based on a ILI9486 or ST7796 driver chip with a 480 x 320 pixel screen. The ILI9486 RPi display must be of the Waveshare design and use a 16 bit serial interface based on the 74HC04, 74HC4040 and 2 x 74HC4094 logic chips. Note that due to design variations between these displays not all RPi displays will work with this library, so purchasing a RPi display of these types soley for use with this library is not recommended.
 
 The "good" RPi displays are the [MHS-4.0 inch Display-B type ST7796](http://www.lcdwiki.com/MHS-4.0inch_Display-B) and [Waveshare 3.5 inch ILI9486 Type C](https://www.waveshare.com/wiki/3.5inch_RPi_LCD_(C)) displays are supported and provides good performance. These have a dedicated controller and can be clocked at up to 80MHz with the ESP32 (55MHz with STM32 and 40MHz with ESP8266).
 

--- a/2.Firmware/Libraries/FastLED/README.md
+++ b/2.Firmware/Libraries/FastLED/README.md
@@ -63,12 +63,12 @@ HL1606, and "595"-style shift registers are no longer supported by the library. 
 
 ## Supported platforms
 
-Right now the library is supported on a variety of arduino compatable platforms.  If it's ARM or AVR and uses the arduino software (or a modified version of it to build) then it is likely supported.  Note that we have a long list of upcoming platforms to support, so if you don't see what you're looking for here, ask, it may be on the roadmap (or may already be supported).  N.B. at the moment we are only supporting the stock compilers that ship with the arduino software.  Support for upgraded compilers, as well as using AVR studio and skipping the arduino entirely, should be coming in a near future release.
+Right now the library is supported on a variety of arduino compatible platforms.  If it's ARM or AVR and uses the arduino software (or a modified version of it to build) then it is likely supported.  Note that we have a long list of upcoming platforms to support, so if you don't see what you're looking for here, ask, it may be on the roadmap (or may already be supported).  N.B. at the moment we are only supporting the stock compilers that ship with the arduino software.  Support for upgraded compilers, as well as using AVR studio and skipping the arduino entirely, should be coming in a near future release.
 
 * Arduino & compatibles - straight up arduino devices, uno, duo, leonardo, mega, nano, etc...
 * Arduino Yún
 * Adafruit Trinket & Gemma - Trinket Pro may be supported, but haven't tested to confirm yet
-* Teensy 2, Teensy++ 2, Teensy 3.0, Teensy 3.1/3.2, Teensy LC, Teensy 3.5, Teensy 3.6, and Teensy 4.0 - arduino compataible from pjrc.com with some extra goodies (note the teensy 3, 3.1, and LC are ARM, not AVR!)
+* Teensy 2, Teensy++ 2, Teensy 3.0, Teensy 3.1/3.2, Teensy LC, Teensy 3.5, Teensy 3.6, and Teensy 4.0 - arduino compatible from pjrc.com with some extra goodies (note the teensy 3, 3.1, and LC are ARM, not AVR!)
 * Arduino Due and the digistump DigiX
 * RFDuino
 * SparkCore

--- a/2.Firmware/Libraries/FastLED/controller.h
+++ b/2.Firmware/Libraries/FastLED/controller.h
@@ -50,7 +50,7 @@ protected:
 
     /// set all the leds on the controller to a given color
     ///@param data the crgb color to set the leds to
-    ///@param nLeds the numner of leds to set to this color
+    ///@param nLeds the number of leds to set to this color
     ///@param scale the rgb scaling value for outputting color
     virtual void showColor(const struct CRGB & data, int nLeds, CRGB scale) = 0;
 
@@ -392,7 +392,7 @@ protected:
 
   /// set all the leds on the controller to a given color
   ///@param data the crgb color to set the leds to
-  ///@param nLeds the numner of leds to set to this color
+  ///@param nLeds the number of leds to set to this color
   ///@param scale the rgb scaling value for outputting color
   virtual void showColor(const struct CRGB & data, int nLeds, CRGB scale) {
     PixelController<RGB_ORDER, LANES, MASK> pixels(data, nLeds, scale, getDither());

--- a/2.Firmware/Libraries/FastLED/fastspi_types.h
+++ b/2.Firmware/Libraries/FastLED/fastspi_types.h
@@ -12,7 +12,7 @@ FASTLED_NAMESPACE_BEGIN
 #define SPI_ADVANCE (3 + (MASK_SKIP_BITS & SKIP))
 
 /// Some of the SPI controllers will need to perform a transform on each byte before doing
-/// anyting with it.  Creating a class of this form and passing it in as a template parameter to
+/// anything with it.  Creating a class of this form and passing it in as a template parameter to
 /// writeBytes/writeBytes3 below will ensure that the body of this method will get called on every
 /// byte worked on.  Recommendation, make the adjust method aggressively inlined.
 ///

--- a/2.Firmware/Libraries/FastLED/pixeltypes.h
+++ b/2.Firmware/Libraries/FastLED/pixeltypes.h
@@ -230,7 +230,7 @@ struct CRGB {
         return *this;
     }
 
-    /// add a contstant to each channel, saturating at 0xFF
+    /// add a constant to each channel, saturating at 0xFF
     /// this is NOT an operator+= overload because the compiler
     /// can't usefully decide when it's being passed a 32-bit
     /// constant (e.g. CRGB::Red) and an 8-bit one (CRGB::Blue)

--- a/2.Firmware/Libraries/FastLED/platforms/arm/common/m0clockless.h
+++ b/2.Firmware/Libraries/FastLED/platforms/arm/common/m0clockless.h
@@ -207,7 +207,7 @@ showLedData(volatile uint32_t *_port, uint32_t _bitmask, const uint8_t *_leds, u
     :
 
     /////////////////////////////////////////////////////////////////////////
-    // now for some convinience macros to make building our lines a bit cleaner
+    // now for some convenience macros to make building our lines a bit cleaner
 #define LOOP            "  loop_%=:"
 #define HI2             "  qset2 %[bitmask], %[port], %[hi_off];"
 #define _D1             "  mod_delay %c[T1],2,0,%[scratch];"

--- a/2.Firmware/Libraries/FastLED/platforms/arm/k20/clockless_block_arm_k20.h
+++ b/2.Firmware/Libraries/FastLED/platforms/arm/k20/clockless_block_arm_k20.h
@@ -112,7 +112,7 @@ public:
 			b.bytes[i+(USED_LANES/2)] = pixels.template loadAndScale<PX>(pixels,i+(USED_LANES/2),d,scale);
 		}
 
-		// if folks use an odd numnber of lanes, get the last byte's value here
+		// if folks use an odd number of lanes, get the last byte's value here
 		if(USED_LANES & 0x01) {
 			b.bytes[USED_LANES-1] = pixels.template loadAndScale<PX>(pixels,USED_LANES-1,d,scale);
 		}

--- a/2.Firmware/Libraries/FastLED/platforms/arm/k66/clockless_block_arm_k66.h
+++ b/2.Firmware/Libraries/FastLED/platforms/arm/k66/clockless_block_arm_k66.h
@@ -126,7 +126,7 @@ public:
 			b.bytes[i+(USED_LANES/2)] = pixels.template loadAndScale<PX>(pixels,i+(USED_LANES/2),d,scale);
 		}
 
-		// if folks use an odd numnber of lanes, get the last byte's value here
+		// if folks use an odd number of lanes, get the last byte's value here
 		if(USED_LANES & 0x01) {
 			b.bytes[USED_LANES-1] = pixels.template loadAndScale<PX>(pixels,USED_LANES-1,d,scale);
 		}

--- a/2.Firmware/Libraries/FastLED/platforms/esp/32/clockless_i2s_esp32.h
+++ b/2.Firmware/Libraries/FastLED/platforms/esp/32/clockless_i2s_esp32.h
@@ -33,7 +33,7 @@
  * 32-bit values -- one for each bit for each strip. The pixel data,
  * however, is stored "serially" as a series of RGB values separately
  * for each strip. To prepare the data we need to do three things: (1)
- * take 1 pixel from each strip, and (2) tranpose the bits so that
+ * take 1 pixel from each strip, and (2) transpose the bits so that
  * they are in the parallel form, (3) translate each data bit into the
  * bit pattern that encodes the signal for that bit. This code is in
  * the fillBuffer() method:
@@ -43,7 +43,7 @@
  *      bytes, then all the blue bytes). For three color channels, the
  *      array is 3 X 24 X 8 bits.
  *
- *   2. Tranpose the array so that it is 3 X 8 X 24 bits. The hardware
+ *   2. Transpose the array so that it is 3 X 8 X 24 bits. The hardware
  *      wants the data in 32-bit chunks, so the actual form is 3 X 8 X
  *      32, with the low 8 bits unused.
  *
@@ -309,7 +309,7 @@ protected:
          */
 
         freq=1000000000L*freq*gPulsesPerBit;
-        // Serial.printf("needed frequency (nbpiulse per bit)*(chispset frequency):%f Mhz\n",freq/1000000);
+        // Serial.printf("needed frequency (nbpiulse per bit)*(chipset frequency):%f Mhz\n",freq/1000000);
         
         /*
          we do calculate the needed N a and b
@@ -648,7 +648,7 @@ protected:
         int buf_index = 0;
         for (int channel = 0; channel < NUM_COLOR_CHANNELS; channel++) {
             
-            // -- Tranpose each array: all the bit 7's, then all the bit 6's, ...
+            // -- Transpose each array: all the bit 7's, then all the bit 6's, ...
             transpose32(gPixelRow[channel], gPixelBits[channel][0] );
             
             //Serial.print("Channel: "); Serial.print(channel); Serial.print(" ");

--- a/2.Firmware/Libraries/TFT_eSPI/Processors/TFT_eSPI_STM32.c
+++ b/2.Firmware/Libraries/TFT_eSPI/Processors/TFT_eSPI_STM32.c
@@ -84,7 +84,7 @@ void TFT_eSPI::end_SDA_Read(void)
 ** Description:             Write a block of pixels of the same colour
 ***************************************************************************************/
 void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
-    // Loop unrolling improves speed dramtically graphics test  0.634s => 0.374s
+    // Loop unrolling improves speed dramatically graphics test  0.634s => 0.374s
     while (len>31) {
     #if !defined (SSD1963_DRIVER)
       // 32D macro writes 16 bits twice

--- a/2.Firmware/Libraries/TFT_eSPI/README.md
+++ b/2.Firmware/Libraries/TFT_eSPI/README.md
@@ -42,7 +42,7 @@ Displays using the following controllers are supported:
 
 ILI9341 and ST7796 SPI based displays are recommended as starting point for experimenting with this library.
 
-The library supports some TFT displays designed for the Raspberry Pi (RPi) that are based on a ILI9486 or ST7796 driver chip with a 480 x 320 pixel screen. The ILI9486 RPi display must be of the Waveshare design and use a 16 bit serial interface based on the 74HC04, 74HC4040 and 2 x 74HC4094 logic chips. Note that due to design variations between these displays not all RPi displays will work with this library, so purchaing a RPi display of these types soley for use with this library is not recommended.
+The library supports some TFT displays designed for the Raspberry Pi (RPi) that are based on a ILI9486 or ST7796 driver chip with a 480 x 320 pixel screen. The ILI9486 RPi display must be of the Waveshare design and use a 16 bit serial interface based on the 74HC04, 74HC4040 and 2 x 74HC4094 logic chips. Note that due to design variations between these displays not all RPi displays will work with this library, so purchasing a RPi display of these types soley for use with this library is not recommended.
 
 The "good" RPi displays are the [MHS-4.0 inch Display-B type ST7796](http://www.lcdwiki.com/MHS-4.0inch_Display-B) and [Waveshare 3.5 inch ILI9486 Type C](https://www.waveshare.com/wiki/3.5inch_RPi_LCD_(C)) displays are supported and provides good performance. These have a dedicated controller and can be clocked at up to 80MHz with the ESP32 (55MHz with STM32 and 40MHz with ESP8266).
 

--- a/2.Firmware/Libraries/lvgl/examples/lvgl_display/porting/lv_port_disp_template.c
+++ b/2.Firmware/Libraries/lvgl/examples/lvgl_display/porting/lv_port_disp_template.c
@@ -55,7 +55,7 @@ void lv_port_disp_init(void)
      *----------------------------*/
 
     /* LVGL requires a buffer where it internally draws the widgets.
-     * Later this buffer will passed your display drivers `flush_cb` to copy its content to your dispay.
+     * Later this buffer will passed your display drivers `flush_cb` to copy its content to your display.
      * The buffer has to be greater than 1 display row
      *
      * There are three buffering configurations:

--- a/2.Firmware/Libraries/lvgl/examples/lvgl_fs/porting/lv_port_disp_template.c
+++ b/2.Firmware/Libraries/lvgl/examples/lvgl_fs/porting/lv_port_disp_template.c
@@ -55,7 +55,7 @@ void lv_port_disp_init(void)
      *----------------------------*/
 
     /* LVGL requires a buffer where it internally draws the widgets.
-     * Later this buffer will passed your display drivers `flush_cb` to copy its content to your dispay.
+     * Later this buffer will passed your display drivers `flush_cb` to copy its content to your display.
      * The buffer has to be greater than 1 display row
      *
      * There are three buffering configurations:

--- a/3.Software/LvglSimulator/vs2019_proj/lv_drivers/lv_drv_conf_template.h
+++ b/3.Software/LvglSimulator/vs2019_proj/lv_drivers/lv_drv_conf_template.h
@@ -365,7 +365,7 @@
 
 #  if EVDEV_CALIBRATE
 #    define EVDEV_HOR_MIN         0               /*to invert axis swap EVDEV_XXX_MIN by EVDEV_XXX_MAX*/
-#    define EVDEV_HOR_MAX      4096               /*"evtest" Linux tool can help to get the correct calibraion values>*/
+#    define EVDEV_HOR_MAX      4096               /*"evtest" Linux tool can help to get the correct calibration values>*/
 #    define EVDEV_VER_MIN         0
 #    define EVDEV_VER_MAX      4096
 #  endif  /*EVDEV_CALIBRATE*/

--- a/3.Software/LvglSimulator/vs2019_proj/lv_drv_conf.h
+++ b/3.Software/LvglSimulator/vs2019_proj/lv_drv_conf.h
@@ -368,7 +368,7 @@
 
 #  if EVDEV_CALIBRATE
 #    define EVDEV_HOR_MIN         0               /*to invert axis swap EVDEV_XXX_MIN by EVDEV_XXX_MAX*/
-#    define EVDEV_HOR_MAX      4096               /*"evtest" Linux tool can help to get the correct calibraion values>*/
+#    define EVDEV_HOR_MAX      4096               /*"evtest" Linux tool can help to get the correct calibration values>*/
 #    define EVDEV_VER_MIN         0
 #    define EVDEV_VER_MAX      4096
 #  endif  /*EVDEV_CALIBRATE*/

--- a/3.Software/LvglSimulator/vs2019_proj/lvgl/examples/porting/lv_port_disp_template.c
+++ b/3.Software/LvglSimulator/vs2019_proj/lvgl/examples/porting/lv_port_disp_template.c
@@ -55,7 +55,7 @@ void lv_port_disp_init(void)
      *----------------------------*/
 
     /* LVGL requires a buffer where it internally draws the widgets.
-     * Later this buffer will passed your display drivers `flush_cb` to copy its content to your dispay.
+     * Later this buffer will passed your display drivers `flush_cb` to copy its content to your display.
      * The buffer has to be greater than 1 display row
      *
      * There are three buffering configurations:

--- a/3.Software/LvglSimulator/vs2019_proj/lvgl/scripts/release.py
+++ b/3.Software/LvglSimulator/vs2019_proj/lvgl/scripts/release.py
@@ -6,7 +6,7 @@
 #
 # STEPS:
 #  - clone all 5 repos
-#  - get the version numnber from lvgl.h
+#  - get the version number from lvgl.h
 #  - set release branch (e.g. "release/v7")
 #  - prepare lvgl
 #    - run lv_conf_internal.py
@@ -17,7 +17,7 @@
 #    - update CHANGELOG.md
 #    - commit changes 
 #  - prepare lv_examples
-#    - upadte the required LVGL version in lv_examples.h (LV_VERSION_CHECK) 
+#    - update the required LVGL version in lv_examples.h (LV_VERSION_CHECK) 
 #    - update the version in lv_ex_conf_template.h
 #  - prepare lv_drivers
 #    - update the version in library.json, lv_drv_conf_template.h      
@@ -410,7 +410,7 @@ def projs_update():
     for p in proj_list:
         os.chdir("./" + p)
         cmd('git checkout master')
-        print(p + ": upadte lvgl");
+        print(p + ": update lvgl");
         cmd("cd lvgl; git co " + release_br + "; git pull origin " + release_br)
         cmd("cp -f lvgl/lv_conf_template.h lv_conf.h")
         cmd("sed -i -r 's/#if 0/#if 1/' lv_conf.h")  # Enable lv_conf.h
@@ -424,11 +424,11 @@ def projs_update():
             define_set("lv_conf.h", str(k), str(v))        
             
         if os.path.exists("lv_examples"): 
-            print(p + ": upadte lv_examples");
+            print(p + ": update lv_examples");
             cmd("cd lv_examples; git co " + release_br + "; git pull origin " + release_br)
             
         if os.path.exists("lv_drivers"): 
-            print(p + ": upadte lv_drivers");
+            print(p + ": update lv_drivers");
             cmd("cd lv_drivers " + release_br + "; git pull origin " + release_br)
 
         msg = 'Update to ' + ver_str


### PR DESCRIPTION
There are small typos in:
- 2.Firmware/HoloCubic-fw/lib/FastLED/README.md
- 2.Firmware/HoloCubic-fw/lib/TFT_eSPI/README.md
- 2.Firmware/Libraries/FastLED/README.md
- 2.Firmware/Libraries/FastLED/controller.h
- 2.Firmware/Libraries/FastLED/fastspi_types.h
- 2.Firmware/Libraries/FastLED/pixeltypes.h
- 2.Firmware/Libraries/FastLED/platforms/arm/common/m0clockless.h
- 2.Firmware/Libraries/FastLED/platforms/arm/k20/clockless_block_arm_k20.h
- 2.Firmware/Libraries/FastLED/platforms/arm/k66/clockless_block_arm_k66.h
- 2.Firmware/Libraries/FastLED/platforms/esp/32/clockless_i2s_esp32.h
- 2.Firmware/Libraries/TFT_eSPI/Processors/TFT_eSPI_STM32.c
- 2.Firmware/Libraries/TFT_eSPI/README.md
- 2.Firmware/Libraries/lvgl/examples/lvgl_display/porting/lv_port_disp_template.c
- 2.Firmware/Libraries/lvgl/examples/lvgl_fs/porting/lv_port_disp_template.c
- 3.Software/LvglSimulator/vs2019_proj/lv_drivers/lv_drv_conf_template.h
- 3.Software/LvglSimulator/vs2019_proj/lv_drv_conf.h
- 3.Software/LvglSimulator/vs2019_proj/lvgl/examples/porting/lv_port_disp_template.c
- 3.Software/LvglSimulator/vs2019_proj/lvgl/scripts/release.py

Fixes:
- Should read `number` rather than `numnber`.
- Should read `display` rather than `dispay`.
- Should read `purchasing` rather than `purchaing`.
- Should read `number` rather than `numner`.
- Should read `compatible` rather than `compataible`.
- Should read `compatible` rather than `compatable`.
- Should read `calibration` rather than `calibraion`.
- Should read `update` rather than `upadte`.
- Should read `transpose` rather than `tranpose`.
- Should read `dramatically` rather than `dramtically`.
- Should read `convenience` rather than `convinience`.
- Should read `constant` rather than `contstant`.
- Should read `chipset` rather than `chispset`.
- Should read `anything` rather than `anyting`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md