### PR TITLE
修改了不能连续使用readFileLine()的bug

### DIFF
--- a/2.Firmware/HoloCubic-fw/src/sd_card.cpp
+++ b/2.Firmware/HoloCubic-fw/src/sd_card.cpp
@@ -141,6 +141,7 @@ String SdCard::readFileLine(const char *path, int num = 1)
                 *(p++) = '\0';
                 String s(buf);
                 s.trim();
+                file.close();
                 return s;
             }
         } else if (num == 1)


### PR DESCRIPTION
打开file后，两个return分支，只有erro parameter会使用`file.close()`。
因此会造成当连续调用readFileLine时，因为没有`file.close`而造成打开文件失败。

因此需要多加一个`file.close()`。