### PR TITLE
[Fw] Init HSPI in sd_card.cpp, avoid use default pins.

### DIFF
--- a/2.Firmware/HoloCubic-fw/src/sd_card.cpp
+++ b/2.Firmware/HoloCubic-fw/src/sd_card.cpp
@@ -5,6 +5,7 @@ void SdCard::init()
 {
 
 	SPIClass* sd_spi = new SPIClass(HSPI); // another SPI
+	sd_spi->begin(14, 26, 13, 15); // Replace default HSPI pins
 	if (!SD.begin(15, *sd_spi)) // SD-Card SS pin is 15
 	{
 		Serial.println("Card Mount Failed");


### PR DESCRIPTION
Init HSPI first,  the spi.begin() in SDFS::begin() will do nothing, so no need to modify the system's esp32 library.